### PR TITLE
Remove shebang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import sys
 


### PR DESCRIPTION
If the user uses a virtual env (such as conda env) it may get the wrong python. It is better to remove this line to avoid any kinda of problem