### PR TITLE
Add a 'publish' target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,7 @@ release: clean
 
 install: clean
 	poetry install
+
+publish:
+	@bin/publish
+

--- a/bin/publish
+++ b/bin/publish
@@ -10,11 +10,34 @@ if [ -z "$PYPI_PASSWORD" ]; then
     exit 1    
 fi
 
-read -p "Are you sure you want to publish $(poetry version) to PyPi? " -n 1 -r
-if [[ ! $REPLY =~ ^[Yy]$ ]]
-then
-    exit 1
+changes=`git diff`
+
+if [ -n "${changes}" ]; then
+  echo "You have made changes to this branch that you have not committed."
+  exit 1
 fi
 
+staged_changes=`git diff --staged`
+
+if [ -n "${staged_changes}" ]; then
+  echo "You have staged changes to this branch that you have not committed."
+  exit 1
+fi
+
+tagged=`git log -1 --decorate | head -1 | grep 'tag:'`
+
+if [ -z "$tagged" ]; then
+  # We don't encourage people to tag it unless they have no changes pending.
+  echo "You can only publish a tagged commit."
+  exit 1
+fi
+
+read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+then
+  echo "Publishing aborted."
+  exit 1
+fi
 
 poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$PYPI_USER" ]; then
+    echo '$PYPI_USER is not set.'
+    exit 1
+fi    
+
+if [ -z "$PYPI_PASSWORD" ]; then
+    echo '$PYPI_PASSWORD is not set.'
+    exit 1    
+fi
+
+read -p "Are you sure you want to publish $(poetry version) to PyPi? " -n 1 -r
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    exit 1
+fi
+
+
+poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-lambda-4dn"
-version = "2.0.0b2"
+version = "2.0.0b3"
 description = "A forked version of python-lambda for 4DN-DCIC use in packaging and deploying lambda functions."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This sets up so that `make publish` will publish to PyPi, assuming that:

* `$PYPI_USER` and `$PYPI_PASSWORD` are set.
* There are no changes on the branch.
* The branch is tagged.
* The user answers "Y" or "Yes" (in any case) to an 'are you sure' query.

This script should be possible to centralize at some point. And we might want to rewrite it in Python so that it can just be imported from a `utils` package, or something like that. But this should suffice for now and can be cut&pasted into other poetry-based repos easily enough as a stopgap.
